### PR TITLE
Going back to var instead of const for module requires.

### DIFF
--- a/jsonist.js
+++ b/jsonist.js
@@ -1,6 +1,6 @@
 var hyperquest = require('hyperquest')
-    , bl         = require('bl')
-    , stringify  = require('json-stringify-safe')
+  , bl         = require('bl')
+  , stringify  = require('json-stringify-safe')
 
 
 function collector (request, callback) {

--- a/jsonist.js
+++ b/jsonist.js
@@ -1,4 +1,4 @@
-const hyperquest = require('hyperquest')
+var hyperquest = require('hyperquest')
     , bl         = require('bl')
     , stringify  = require('json-stringify-safe')
 


### PR DESCRIPTION
Hi Rod,
I like the simplicity of jsonist and was trying to use it for an IoT project on the Tessel board. However, the const keyword is technically ES6 and doesn't work on that platform. Any chance you would accept reverting back to using var?