### PR TITLE
enable .pipe() during POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Send a POST request to `url`, writing JSON serialised data to the request, and r
 
 `'method'` is set to `'POST'` for you before passing on to hyperquest.
 
+The `data` parameter can also be a readable stream that will get `.pipe()`'d to the request.
+
 The `options` object is optional and is passed on to hyperquest.
 
 ### jsonist.put(url, data, [ options, ] callback)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Send a POST request to `url`, writing JSON serialised data to the request, and r
 
 The `options` object is optional and is passed on to hyperquest.
 
-### jsonist.put(url, [ options, ] callback)
+### jsonist.put(url, data, [ options, ] callback)
 
 Same as  `jsonist.post()` but for when that extra character is too much to type or you have to use someone's overloaded API. `'method'` is set to `'PUT'`.
 

--- a/jsonist.js
+++ b/jsonist.js
@@ -53,7 +53,11 @@ function makeMethod (method, data) {
   }
 
   function dataHandler (url, data, options, callback) {
-    return handler(url, options, callback).end(stringify(data))
+    var request = handler(url, options, callback)
+    if (typeof data.pipe == 'function')
+      data.pipe(request)
+    else
+      request.end(stringify(data))
   }
 
   return data ? dataHandler : handler

--- a/jsonist.js
+++ b/jsonist.js
@@ -58,6 +58,7 @@ function makeMethod (method, data) {
       data.pipe(request)
     else
       request.end(stringify(data))
+    return request
   }
 
   return data ? dataHandler : handler

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple wrapper around for dealing with JSON web APIs",
   "main": "jsonist.js",
   "scripts": {
-    "test": "node test.js"
+    "test": "node test.js | faucet"
   },
   "repository": {
     "type": "git",
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/rvagg/jsonist",
   "devDependencies": {
+    "faucet": "0.0.1",
     "tape": "~3.5.0",
     "xtend": "~4.0.0"
   }


### PR DESCRIPTION
Allow the user to pass in a stream instead of data object. Useful when uploading files via e.g. `fs.createReadStream('/path/to/file')`