### PR TITLE
deal with http errors

### DIFF
--- a/jsonist.js
+++ b/jsonist.js
@@ -3,14 +3,15 @@ var hyperquest = require('hyperquest')
   , stringify  = require('json-stringify-safe')
 
 
-function HttpError(status, request) {
-    this.status = status;
-    this.request = request;
-    Error.captureStackTrace(this, HttpError)
+function HttpError (status, request) {
+    Error.call(this)
+    this.status = status
+    this.request = request
+    Error.captureStackTrace(this, arguments.callee)
 }
 
-HttpError.prototype = Object.create(Error.prototype);
-HttpError.prototype.constructor = HttpError;
+HttpError.prototype = Object.create(Error.prototype)
+HttpError.prototype.constructor = HttpError
 
 
 function collector (request, callback) {
@@ -26,7 +27,7 @@ function collector (request, callback) {
     try {
       ret = JSON.parse(data.toString())
     } catch (e) {
-        if(request.response.statusCode >= 300) {
+        if (request.response.statusCode >= 300) {
             var httpError = new HttpError(request.response.statusCode, request)
             return callback(httpError);
         } else {
@@ -83,4 +84,5 @@ function makeMethod (method, data) {
 module.exports.get  = makeMethod('GET'  , false)
 module.exports.post = makeMethod('POST' , true)
 module.exports.put  = makeMethod('PUT'  , true)
-module.exports.HttpError = HttpError;
+module.exports.HttpError = HttpError
+

--- a/jsonist.js
+++ b/jsonist.js
@@ -3,10 +3,10 @@ var hyperquest = require('hyperquest')
   , stringify  = require('json-stringify-safe')
 
 
-function HttpError (status, request) {
+function HttpError (status, response) {
     Error.call(this)
     this.status = status
-    this.request = request
+    this.response = response
     Error.captureStackTrace(this, arguments.callee)
 }
 
@@ -28,7 +28,7 @@ function collector (request, callback) {
       ret = JSON.parse(data.toString())
     } catch (e) {
         if (request.response.statusCode >= 300) {
-            var httpError = new HttpError(request.response.statusCode, request)
+            var httpError = new HttpError(request.response.statusCode, request.response)
             return callback(httpError);
         } else {
             var err2 = new SyntaxError('JSON parse error: ' + e.message, e)
@@ -85,4 +85,3 @@ module.exports.get  = makeMethod('GET'  , false)
 module.exports.post = makeMethod('POST' , true)
 module.exports.put  = makeMethod('PUT'  , true)
 module.exports.HttpError = HttpError
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonist",
-  "version": "1.1.1-QF",
+  "version": "1.1.2-QF",
   "description": "A simple wrapper around for dealing with JSON web APIs",
   "main": "jsonist.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonist",
-  "version": "1.1.0",
+  "version": "1.1.1-QF",
   "description": "A simple wrapper around for dealing with JSON web APIs",
   "main": "jsonist.js",
   "scripts": {


### PR DESCRIPTION
try to fix #7 as proposed by @rvagg.

In case that the http error is returned with valid json, it will not be 'callbacked' as an error but as a valid result where the response.status can be checked... not sure if that's what most people would want, but it works for me.
